### PR TITLE
chore(types): Add TypeScript types for nutrient tracking

### DIFF
--- a/web/src/types/data.ts
+++ b/web/src/types/data.ts
@@ -27,3 +27,53 @@ export type RecipeDetail = {
     | "vit_k_microg"
   >;
 };
+
+// Nutrient Tracking Types (v1.1.0)
+
+/**
+ * Base nutrient data structure containing essential macronutrients and micronutrients
+ */
+export interface NutrientData {
+  calories_kcal: number;
+  protein_g: number;
+  carbs_g: number;
+  fats_g: number;
+  fiber_g?: number;
+  sugar_g?: number;
+  sodium_mg?: number;
+}
+
+/**
+ * Daily nutrient summary for a specific date
+ */
+export interface DailyNutrient extends NutrientData {
+  date: string; // YYYY-MM-DD format
+  meal_count: number;
+  user_id: string;
+}
+
+/**
+ * Weekly nutrient aggregation with date range
+ */
+export interface WeeklyNutrient extends NutrientData {
+  week_start: string; // YYYY-MM-DD format
+  week_end: string; // YYYY-MM-DD format
+  days_tracked: number;
+}
+
+/**
+ * Monthly nutrient aggregation
+ */
+export interface MonthlyNutrient extends NutrientData {
+  month: string; // YYYY-MM format (e.g., "2025-11")
+  days_tracked: number;
+}
+
+/**
+ * API response structure for nutrient summary endpoint
+ */
+export interface NutrientSummaryResponse {
+  daily: DailyNutrient | null;
+  weekly: WeeklyNutrient[];
+  monthly: MonthlyNutrient[];
+}


### PR DESCRIPTION
## 📝 Pull Request

### Summary
Add TypeScript type definitions for the nutrient tracking feature (v1.1.0). These types will be used by the nutrient dashboard page, API routes, and components.

### Related Issue
Closes #13

### Type of Change
- [x] 🔧 Refactoring

### Changes Made
- Added `NutrientData` base interface with 7 nutrient fields
- Added `DailyNutrient` interface for daily summaries
- Added `WeeklyNutrient` interface for weekly aggregations
- Added `MonthlyNutrient` interface for monthly aggregations
- Added `NutrientSummaryResponse` for API response structure
- Added JSDoc comments for all new types

### Testing Evidence
- [x] Manual testing completed
- [x] All existing tests pass

**Test Results:**
Types added successfully to `web/src/types/data.ts`. No runtime changes, purely type definitions.

### Breaking Changes
- [ ] This PR introduces breaking changes

### Documentation Updates
- [ ] ✅ Updated `AGENT-PLAN/08-SPRINT-TASKS.md` with issue status/progress

### Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] No console.log or debug code left
- [x] Branch is up to date with base branch
- [x] Commit messages follow convention

### Review Notes
Pure TypeScript type definition addition with no runtime changes. Types follow existing project naming conventions.

### Deployment Notes
No deployment changes needed. Type-only change for future nutrient tracking feature.