### PR TITLE
chore(database): Add nutrient_tracking table migration

### DIFF
--- a/supabase/migrations/20251122000000_add_nutrient_tracking_table.sql
+++ b/supabase/migrations/20251122000000_add_nutrient_tracking_table.sql
@@ -1,0 +1,49 @@
+-- Create nutrient_tracking table for storing daily aggregated nutrient data
+CREATE TABLE IF NOT EXISTS nutrient_tracking (
+  id SERIAL PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  date DATE NOT NULL,
+  calories_kcal NUMERIC(10,2) DEFAULT 0,
+  protein_g NUMERIC(10,2) DEFAULT 0,
+  carbs_g NUMERIC(10,2) DEFAULT 0,
+  fats_g NUMERIC(10,2) DEFAULT 0,
+  fiber_g NUMERIC(10,2) DEFAULT 0,
+  sugar_g NUMERIC(10,2) DEFAULT 0,
+  sodium_mg NUMERIC(10,2) DEFAULT 0,
+  meal_count INTEGER DEFAULT 0,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW(),
+  UNIQUE(user_id, date)
+);
+
+-- Create index for efficient queries by user and date
+CREATE INDEX idx_nutrient_tracking_user_date ON nutrient_tracking(user_id, date DESC);
+
+-- Create index for monthly aggregations
+CREATE INDEX idx_nutrient_tracking_user_month ON nutrient_tracking(user_id, DATE_TRUNC('month', date));
+
+-- Enable Row Level Security
+ALTER TABLE nutrient_tracking ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Users can view their own nutrient data
+CREATE POLICY "Users can view own nutrient data"
+  ON nutrient_tracking FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Policy: Users can insert their own nutrient data
+CREATE POLICY "Users can insert own nutrient data"
+  ON nutrient_tracking FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- Policy: Users can update their own nutrient data
+CREATE POLICY "Users can update own nutrient data"
+  ON nutrient_tracking FOR UPDATE
+  USING (auth.uid() = user_id);
+
+-- Policy: Users can delete their own nutrient data
+CREATE POLICY "Users can delete own nutrient data"
+  ON nutrient_tracking FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- Add comment for documentation
+COMMENT ON TABLE nutrient_tracking IS 'Stores daily aggregated nutrient data calculated from user meal logs';


### PR DESCRIPTION
## 📝 Pull Request

### Summary
Create Supabase migration to add the `nutrient_tracking` table for storing daily aggregated nutrient data.

### Related Issue
Closes #14

### Type of Change
- [ ] 🎨 Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Refactoring
- [ ] 📚 Documentation
- [ ] ✅ Testing
- [x] ⚙️ Infrastructure/DevOps

### Changes Made
- Created migration file `20251122000000_add_nutrient_tracking_table.sql`
- Defined `nutrient_tracking` table schema with 10 nutrient columns
- Added indexes for efficient queries:
  - `idx_nutrient_tracking_user_date` for user+date queries
  - `idx_nutrient_tracking_user_month` for monthly aggregations
- Added Row Level Security (RLS) policies for all CRUD operations
- Added UNIQUE constraint on (user_id, date) to prevent duplicates

### Testing Evidence
- [x] Migration file created
- [ ] Local Supabase test (requires `npx supabase@beta db reset`)

**Migration SQL:**
```sql
CREATE TABLE nutrient_tracking (
  id SERIAL PRIMARY KEY,
  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
  date DATE NOT NULL,
  calories_kcal NUMERIC(10,2) DEFAULT 0,
  protein_g NUMERIC(10,2) DEFAULT 0,
  carbs_g NUMERIC(10,2) DEFAULT 0,
  fats_g NUMERIC(10,2) DEFAULT 0,
  fiber_g NUMERIC(10,2) DEFAULT 0,
  sugar_g NUMERIC(10,2) DEFAULT 0,
  sodium_mg NUMERIC(10,2) DEFAULT 0,
  meal_count INTEGER DEFAULT 0,
  UNIQUE(user_id, date)
);
```

### Breaking Changes
- [ ] This PR introduces breaking changes

### Documentation Updates
- [ ] ✅ Updated `AGENT-PLAN/08-SPRINT-TASKS.md` with issue status/progress

### Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added in SQL file
- [x] Branch is up to date with base branch
- [x] Commit messages follow convention

### Review Notes
- RLS policies ensure users can only access their own data
- Indexes optimize common query patterns (daily lookups, monthly aggregations)
- UNIQUE constraint prevents duplicate entries for the same user+date

### Deployment Notes
Migration will be applied automatically by Supabase on merge. Test locally with `npx supabase@beta db reset`.