### PR TITLE
feat: add nutrient goals table and API endpoint

### DIFF
--- a/supabase/migrations/20251125000000_add_nutrient_goals_table.sql
+++ b/supabase/migrations/20251125000000_add_nutrient_goals_table.sql
@@ -1,0 +1,40 @@
+-- Create nutrient_goals table to store a user's target macros and micros
+CREATE TABLE IF NOT EXISTS nutrient_goals (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  calories_kcal NUMERIC(10, 2) DEFAULT 0,
+  protein_g NUMERIC(10, 2) DEFAULT 0,
+  carbs_g NUMERIC(10, 2) DEFAULT 0,
+  fats_g NUMERIC(10, 2) DEFAULT 0,
+  sodium_mg NUMERIC(10, 2) DEFAULT 0,
+  fiber_g NUMERIC(10, 2) DEFAULT 0,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Primary key enforces single-row-per-user and provides an index for lookups
+
+-- Enable Row Level Security
+ALTER TABLE nutrient_goals ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Users can view their own nutrient goals
+CREATE POLICY "Users can view own nutrient goals"
+  ON nutrient_goals FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Policy: Users can insert their own nutrient goals
+CREATE POLICY "Users can insert own nutrient goals"
+  ON nutrient_goals FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- Policy: Users can update their own nutrient goals
+CREATE POLICY "Users can update own nutrient goals"
+  ON nutrient_goals FOR UPDATE
+  USING (auth.uid() = user_id);
+
+-- Policy: Users can delete their own nutrient goals
+CREATE POLICY "Users can delete own nutrient goals"
+  ON nutrient_goals FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- Add comment for documentation
+COMMENT ON TABLE nutrient_goals IS 'Stores per-user nutrient targets for goal tracking';

--- a/web/__tests__/node/nutrientGoalsApi.test.ts
+++ b/web/__tests__/node/nutrientGoalsApi.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET, PUT } from "@/app/api/nutrients/goals/route";
+import { createClient } from "@/utils/supabase/server";
+
+jest.mock("@/utils/supabase/server", () => ({
+  createClient: jest.fn(),
+}));
+
+const mockAuthGetUser = jest.fn();
+const mockFrom = jest.fn();
+
+const createRequest = (method: string, body?: unknown) =>
+  new Request("http://localhost/api/nutrients/goals", {
+    method,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (createClient as jest.Mock).mockResolvedValue({
+    auth: { getUser: mockAuthGetUser },
+    from: mockFrom,
+  });
+
+  mockAuthGetUser.mockResolvedValue({
+    data: { user: { id: "auth-user-1" } },
+    error: null,
+  });
+});
+
+describe("GET /api/nutrients/goals", () => {
+  it("returns 401 when authentication fails", async () => {
+    mockAuthGetUser.mockResolvedValue({ data: { user: null }, error: new Error("No session") });
+
+    const res = await GET();
+    const json = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(json.error).toContain("User not authenticated");
+  });
+
+  it("returns null goal when no record exists", async () => {
+    const mockMaybeSingle = jest.fn().mockResolvedValue({ data: null, error: null });
+    const query = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: mockMaybeSingle,
+    };
+    mockFrom.mockImplementationOnce(() => query);
+
+    const res = await GET();
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({ goal: null });
+    expect(mockMaybeSingle).toHaveBeenCalled();
+  });
+});
+
+describe("PUT /api/nutrients/goals", () => {
+  it("returns 400 when no goal fields are provided", async () => {
+    const res = await PUT(createRequest("PUT", {}));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain("At least one goal field");
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("merges existing values and upserts new goals", async () => {
+    const existingGoal = {
+      calories_kcal: 2000,
+      protein_g: 150,
+      carbs_g: 240,
+      fats_g: 70,
+      sodium_mg: 1800,
+      fiber_g: 30,
+      created_at: "2025-11-20T00:00:00Z",
+    };
+
+    const updatedGoal = {
+      ...existingGoal,
+      calories_kcal: 2200,
+      protein_g: 160,
+      updated_at: "2025-11-21T00:00:00Z",
+      user_id: "auth-user-1",
+    };
+
+    const fetchMaybeSingle = jest.fn().mockResolvedValue({ data: existingGoal, error: null });
+    const fetchQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: fetchMaybeSingle,
+    };
+
+    const upsertSingle = jest.fn().mockResolvedValue({ data: updatedGoal, error: null });
+    const upsertSelect = jest.fn().mockReturnValue({ single: upsertSingle });
+    const upsert = jest.fn().mockReturnValue({ select: upsertSelect });
+    const upsertQuery = { upsert };
+
+    mockFrom.mockImplementationOnce(() => fetchQuery).mockImplementationOnce(() => upsertQuery);
+
+    const payload = { calories_kcal: 2200, protein_g: 160 };
+    const res = await PUT(createRequest("PUT", payload));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.goal).toEqual(updatedGoal);
+    expect(fetchMaybeSingle).toHaveBeenCalled();
+    expect(upsert).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          user_id: "auth-user-1",
+          calories_kcal: 2200,
+          protein_g: 160,
+          carbs_g: existingGoal.carbs_g,
+          fats_g: existingGoal.fats_g,
+          sodium_mg: existingGoal.sodium_mg,
+          fiber_g: existingGoal.fiber_g,
+        }),
+      ],
+      { onConflict: "user_id" }
+    );
+    expect(upsertSelect).toHaveBeenCalledWith(
+      "user_id, calories_kcal, protein_g, carbs_g, fats_g, sodium_mg, fiber_g, created_at, updated_at"
+    );
+    expect(upsertSingle).toHaveBeenCalled();
+  });
+});

--- a/web/src/app/api/nutrients/goals/route.ts
+++ b/web/src/app/api/nutrients/goals/route.ts
@@ -1,0 +1,153 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+
+const GOAL_FIELDS = [
+  "calories_kcal",
+  "protein_g",
+  "carbs_g",
+  "fats_g",
+  "sodium_mg",
+  "fiber_g",
+] as const;
+type GoalField = (typeof GOAL_FIELDS)[number];
+
+type GoalValues = Partial<Record<GoalField, number>>;
+
+type SupabaseServerClient = Awaited<ReturnType<typeof createClient>>;
+
+type NutrientGoalRow = Record<GoalField, number | null> & {
+  created_at?: string | null;
+  updated_at?: string | null;
+};
+
+async function requireAuthUserId(supabase: SupabaseServerClient): Promise<string> {
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    throw new Error("User not authenticated");
+  }
+
+  return user.id;
+}
+
+function parseGoalPayload(body: unknown): { payload?: GoalValues; error?: string } {
+  if (!body || typeof body !== "object") {
+    return { error: "Invalid payload" };
+  }
+
+  const payload: GoalValues = {};
+  let hasField = false;
+
+  for (const field of GOAL_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(body, field)) {
+      const value = (body as Record<string, unknown>)[field];
+      if (typeof value !== "number" || Number.isNaN(value)) {
+        return { error: `Invalid value for ${field}` };
+      }
+      payload[field] = value;
+      hasField = true;
+    }
+  }
+
+  if (!hasField) {
+    return { error: "At least one goal field must be provided" };
+  }
+
+  return { payload };
+}
+
+export async function GET() {
+  const supabase = await createClient();
+
+  let userId: string;
+  try {
+    userId = await requireAuthUserId(supabase);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unauthorized";
+    return NextResponse.json({ error: message }, { status: 401 });
+  }
+
+  const { data: goal, error } = await supabase
+    .from("nutrient_goals")
+    .select(
+      "user_id, calories_kcal, protein_g, carbs_g, fats_g, sodium_mg, fiber_g, created_at, updated_at"
+    )
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (error) {
+    console.error("GET /api/nutrients/goals error:", error.message);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ goal: goal ?? null });
+}
+
+export async function PUT(request: Request) {
+  const supabase = await createClient();
+
+  let userId: string;
+  try {
+    userId = await requireAuthUserId(supabase);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unauthorized";
+    return NextResponse.json({ error: message }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { payload, error: payloadError } = parseGoalPayload(body);
+  if (payloadError || !payload) {
+    return NextResponse.json({ error: payloadError ?? "Invalid payload" }, { status: 400 });
+  }
+
+  const { data: existingGoal, error: fetchError } = await supabase
+    .from("nutrient_goals")
+    .select("calories_kcal, protein_g, carbs_g, fats_g, sodium_mg, fiber_g, created_at")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (fetchError) {
+    console.error("PUT /api/nutrients/goals fetch error:", fetchError.message);
+    return NextResponse.json({ error: fetchError.message }, { status: 500 });
+  }
+
+  const mergedGoals = GOAL_FIELDS.reduce<Record<GoalField, number>>(
+    (acc, field) => {
+      const incoming = payload[field];
+      const existing = (existingGoal as NutrientGoalRow | null)?.[field] ?? 0;
+      acc[field] = typeof incoming === "number" ? incoming : existing;
+      return acc;
+    },
+    {} as Record<GoalField, number>
+  );
+
+  const upsertInput = {
+    user_id: userId,
+    ...mergedGoals,
+    updated_at: new Date().toISOString(),
+  };
+
+  const { data: goal, error: upsertError } = await supabase
+    .from("nutrient_goals")
+    .upsert([upsertInput], { onConflict: "user_id" })
+    .select(
+      "user_id, calories_kcal, protein_g, carbs_g, fats_g, sodium_mg, fiber_g, created_at, updated_at"
+    )
+    .single();
+
+  if (upsertError) {
+    console.error("PUT /api/nutrients/goals upsert error:", upsertError.message);
+    return NextResponse.json({ error: upsertError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ goal });
+}


### PR DESCRIPTION
Close #28 

This pull request introduces a new feature for tracking per-user nutrient goals, including backend database support, an authenticated API route for reading and updating goals, and comprehensive tests for the new API. The changes ensure that users can securely manage their own nutrient targets, with robust error handling and input validation.

**Database changes (nutrient goals storage):**
* Added a new `nutrient_goals` table to store per-user macro and micro nutrient targets, with fields for calories, protein, carbs, fats, sodium, and fiber. Row-level security policies restrict access so users can only view and modify their own data.

**API implementation (authenticated goal management):**
* Created a new API route (`route.ts`) that provides `GET` and `PUT` endpoints for retrieving and updating the authenticated user's nutrient goals. Includes input validation, merging/upserting logic, and error handling for authentication and database issues.

**Testing (API behavior and edge cases):**
* Added unit tests for the nutrient goals API, covering authentication failures, missing data, input validation, and correct merging/upserting of goal values.