### PR TITLE
docs: add environment variables documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,6 +26,34 @@ npm install
 
 ---
 
+## Environment Variables
+
+Copy the example environment file and configure your variables:
+
+```bash
+cp .env.example .env.local
+```
+
+Edit `.env.local` with your values:
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `NEXT_PUBLIC_SUPABASE_URL` | Your Supabase project URL | Yes |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Your Supabase anonymous key | Yes |
+| `NEXT_PUBLIC_VAPID_PUBLIC_KEY` | VAPID public key for push notifications | For push notifications |
+| `VAPID_PRIVATE_KEY` | VAPID private key for push notifications | For push notifications |
+| `VAPID_SUBJECT` | Contact email for push notifications | For push notifications |
+
+### Generate VAPID Keys (Optional - for Push Notifications)
+
+```bash
+npx web-push generate-vapid-keys
+```
+
+Copy the generated keys to your `.env.local` file.
+
+---
+
 ## Start Development Server
 
 ```bash

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,9 @@
+# Supabase Configuration
+NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+
+# Push Notifications (VAPID)
+# Generate keys with: npx web-push generate-vapid-keys
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=your_vapid_public_key
+VAPID_PRIVATE_KEY=your_vapid_private_key
+VAPID_SUBJECT=mailto:your-email@example.com

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
Adds missing documentation for environment variables setup:

- Created `.env.example` template file
- Updated `INSTALL.md` with environment variables section
- Updated `.gitignore` to allow `.env.example`

This was missed in PR #72.