### PR TITLE
fix(test): Fix StreakWidget timezone-sensitive test failure (#126)

### DIFF
--- a/web/__tests__/jsdom/StreakWidget.test.tsx
+++ b/web/__tests__/jsdom/StreakWidget.test.tsx
@@ -12,16 +12,24 @@ import type { StreaksResponse } from "@/types/data";
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
-// Helper to get yesterday's date in YYYY-MM-DD format
+// Helper to get yesterday's date in YYYY-MM-DD format (local timezone)
 const getYesterday = () => {
   const date = new Date();
   date.setDate(date.getDate() - 1);
-  return date.toISOString().split("T")[0];
+  // Use local date formatting to avoid timezone issues
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 };
 
-// Helper to get today's date in YYYY-MM-DD format
+// Helper to get today's date in YYYY-MM-DD format (local timezone)
 const getToday = () => {
-  return new Date().toISOString().split("T")[0];
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 };
 
 describe("StreakWidget", () => {

--- a/web/src/components/ui/StreakWidget.tsx
+++ b/web/src/components/ui/StreakWidget.tsx
@@ -81,7 +81,9 @@ function isStreakAtRisk(streak: StreakData): boolean {
   // If last activity was yesterday or earlier, streak is at risk
   if (!streak.lastActivity) return false;
 
-  const lastDate = new Date(streak.lastActivity);
+  // Parse date string as local time by appending time component
+  // This avoids timezone issues with YYYY-MM-DD format being parsed as UTC
+  const lastDate = new Date(streak.lastActivity + "T00:00:00");
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   lastDate.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## Summary
Fix intermittent test failure in StreakWidget 'should show warning when streak is at risk' test.

## Problem
The test failed in morning/afternoon EST when UTC date differs from local date. The `getYesterday()` helper returned a date string (e.g., '2025-11-29') that was then parsed as UTC midnight, causing `diffDays` to be 2 instead of 1.

## Root Cause
```javascript
// This parses '2025-11-29' as UTC midnight (00:00 UTC)
new Date('2025-11-29')  

// But setHours(0,0,0,0) uses local timezone
// In EST (UTC-5), this creates a mismatch
```

## Solution
1. **Test helpers**: Changed from `toISOString().split('T')[0]` to explicit local date formatting
2. **Component**: Added `T00:00:00` suffix to force local timezone parsing in `isStreakAtRisk()`

## Files Changed
- `web/__tests__/jsdom/StreakWidget.test.tsx` - Fixed `getYesterday()` and `getToday()` helpers
- `web/src/components/ui/StreakWidget.tsx` - Fixed `isStreakAtRisk()` date parsing

## Testing
- ✅ All 26 StreakWidget tests pass
- ✅ Full test suite passes (688/689, 1 skipped)

Fixes #126