### PR TITLE
feat: Add concurrently to run frontend and backend together (#130)

### DIFF
--- a/AGENT-PLAN/00-QUICK-START.md
+++ b/AGENT-PLAN/00-QUICK-START.md
@@ -31,6 +31,16 @@ npm test                 # Run all tests
 npm run lint             # Run ESLint
 ```
 
+### Full Stack (Frontend + Backend)
+
+```bash
+cd web
+npm run dev:full         # Start both Next.js and FastAPI together
+# Or start separately:
+npm run dev:frontend     # Start only Next.js (http://localhost:3000)
+npm run dev:backend      # Start only FastAPI (http://localhost:8000)
+```
+
 ### Backend (FastAPI)
 
 ```bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,8 +56,24 @@ Copy the generated keys to your `.env.local` file.
 
 ## Start Development Server
 
+### Full Stack (Recommended)
+
+Start both Next.js frontend and FastAPI backend together:
+
 ```bash
-npm run dev
+npm run dev:full
+```
+
+### Frontend Only
+
+```bash
+npm run dev          # or npm run dev:frontend
+```
+
+### Backend Only
+
+```bash
+npm run dev:backend  # or: cd ../backend && make dev
 ```
 
 ---

--- a/web/README.md
+++ b/web/README.md
@@ -12,7 +12,10 @@ TypeScript
 
 ```bash
 npm install
-npm run dev
+npm run dev:full     # Start both frontend + backend
+# Or start separately:
+npm run dev          # Start only frontend (http://localhost:3000)
+npm run dev:backend  # Start only backend (http://localhost:8000)
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -61,6 +61,7 @@
         "@types/supertest": "^6.0.3",
         "@types/web-push": "^3.6.4",
         "autoprefixer": "^10.4.21",
+        "concurrently": "^9.2.1",
         "eslint": "^9",
         "eslint-config-next": "15.5.4",
         "identity-obj-proxy": "^3.0.0",
@@ -6668,6 +6669,47 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -13490,6 +13532,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -13714,6 +13766,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -14520,6 +14585,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/trim-lines": {

--- a/web/package.json
+++ b/web/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
+    "dev:frontend": "next dev --turbopack",
+    "dev:backend": "cd ../backend && make dev",
+    "dev:full": "concurrently -n \"frontend,backend\" -c \"cyan,magenta\" \"npm run dev:frontend\" \"npm run dev:backend\"",
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
@@ -64,6 +67,7 @@
     "@types/supertest": "^6.0.3",
     "@types/web-push": "^3.6.4",
     "autoprefixer": "^10.4.21",
+    "concurrently": "^9.2.1",
     "eslint": "^9",
     "eslint-config-next": "15.5.4",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
## Summary
Add ability to start both Next.js frontend and FastAPI backend with a single command using `concurrently`.

## Changes

### New npm Scripts
| Script | Description |
|--------|-------------|
| `npm run dev:full` | Start both frontend + backend |
| `npm run dev:frontend` | Start only Next.js |
| `npm run dev:backend` | Start only FastAPI |
| `npm run dev` | Unchanged (frontend only) |

### Documentation Updated
- `AGENT-PLAN/00-QUICK-START.md`
- `INSTALL.md`
- `web/README.md`

## Usage
```bash
cd web
npm run dev:full     # Start both services with colored output
```

Output shows frontend in cyan and backend in magenta for easy differentiation.

## Testing
- ✅ All 688 tests pass
- ✅ `npm run dev:full` starts both services correctly

Closes #130